### PR TITLE
Ability to apply .env on Vim start

### DIFF
--- a/plugin/dotenv.vim
+++ b/plugin/dotenv.vim
@@ -183,6 +183,13 @@ if !has_key(g:projectionist_heuristics, "Procfile") && executable('foreman')
         \ "*": {"start": "foreman start"}}
 endif
 
+if exists('g:dotenv_autoload')
+  let file = DotenvFile()
+  if !empty(file)
+    execute s:Load(0, file)
+  endif
+endif
+
 augroup dotenvPlugin
   autocmd BufNewFile,BufReadPost .env.* setfiletype sh
 


### PR DESCRIPTION
I use `.env` file in projects to set some specific environment variables, for example `$PYTHONPATH`.
But I didn't find any way to automatically find and apply the nearest `.env` on Vim start. Doing it interactively every time I start Vim isn't very useful.
So I added `dotenv_autoload` variable.